### PR TITLE
Fix test in GetHomeDirectory001.hs to use XdgState

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: tools/testscript prepare
       - run: tools/testscript build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sdist
+          path: dist-newstyle/sdist/*-*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           cabal-version: ${{ matrix.cabal }}
           enable-stack: ${{ matrix.stack }}
           stack-no-global: ${{ matrix.stack }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: tools/testscript prepare
       - run: tools/testscript build
       - uses: actions/upload-artifact@v3

--- a/tests/GetHomeDirectory001.hs
+++ b/tests/GetHomeDirectory001.hs
@@ -10,7 +10,7 @@ main _t = do
   _ <- getXdgDirectory XdgCache  "test"
   _ <- getXdgDirectory XdgConfig "test"
   _ <- getXdgDirectory XdgData   "test"
-  _ <- getXdgDirectory XdgCache  "test"
+  _ <- getXdgDirectory XdgState  "test"
   _ <- getUserDocumentsDirectory
   _ <- getTemporaryDirectory
   return ()

--- a/tools/testscript
+++ b/tools/testscript
@@ -28,10 +28,15 @@ EOF
 
     else
 
+        cat >cabal.project <<EOF
+packages: *.cabal
+package directory
+  ghc-options: $ghcflags
+EOF
         ghc --version
         cabal --version
         tools/retry cabal update
-        cabal v2-configure -v2 --enable-tests --ghc-options="$ghcflags"
+        cabal v2-configure -v2 --enable-tests
 
     fi
 }


### PR DESCRIPTION
The previous Pull Request [Add support for XDG_STATE_HOME](https://github.com/haskell/directory/pull/121) appears to contain a copy&paste error in one of the tests. 

See here where it adds a line with `XdgCache` instead of `XdgState`:

https://github.com/haskell/directory/pull/121/files#diff-aabb252486b56d0d2bb8efedbd8f52e42a2db1b44b8bf9b75b61b6e72c7950d8R13

This pull request fixes it.